### PR TITLE
Fix code example in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -278,7 +278,7 @@ Quick example: ::
 
         mixer.register(Test,
             name=lambda: 'John',
-            id=lambda: str(mixer.g.get_positive_integer())
+            id=lambda: str(mixer.faker.small_positive_integer())
         )
 
         test = mixer.blend(Test)


### PR DESCRIPTION
no attr `g`; but can use `faker` generator method; seems to preserve the idea of the example.